### PR TITLE
chore: bump version to 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You always need:
 ```toml
 # libs.versions.toml
 [versions]
-updraft = "2.0.0"
+updraft = "2.0.1"
 
 [libraries]
 updraft-sdk = { module = "com.appswithlove.updraft:updraft-sdk", version.ref = "updraft" }

--- a/updraft-core/gradle.properties
+++ b/updraft-core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.appswithlove.updraft
 POM_ARTIFACT_ID=updraft-core
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=updraft-core
 POM_DESCRIPTION=Kotlin Multiplatform core logic for connecting with GetUpdraft platform

--- a/updraft-sdk/gradle.properties
+++ b/updraft-sdk/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx4096m
 
 GROUP=com.appswithlove.updraft
 POM_ARTIFACT_ID=updraft-sdk
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=updraft-sdk
 POM_DESCRIPTION=Updraft SDK for Android: auto-update and user feedback, wired up automatically

--- a/updraft-ui-compose/gradle.properties
+++ b/updraft-ui-compose/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.appswithlove.updraft
 POM_ARTIFACT_ID=updraft-ui-compose
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=updraft-ui-compose
 POM_DESCRIPTION=Compose Multiplatform UI components for the Updraft SDK


### PR DESCRIPTION
Bumps `VERSION_NAME` to 2.0.1 in all three published modules and updates the README install snippet.

- `updraft-sdk/gradle.properties`
- `updraft-core/gradle.properties`
- `updraft-ui-compose/gradle.properties`
- `README.md` (version catalog snippet)

Required before pushing `main` → `production`: the publish workflow reads `VERSION_NAME` from `updraft-sdk/gradle.properties` and fails if that version is already tagged (2.0.0 is).