### PR TITLE
Fix shake-to-feedback crash on Compose / hardware-bitmap screens (2.0.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You always need:
 ```toml
 # libs.versions.toml
 [versions]
-updraft = "2.0.0"
+updraft = "2.0.1"
 
 [libraries]
 updraft-sdk = { module = "com.appswithlove.updraft:updraft-sdk", version.ref = "updraft" }

--- a/README.md
+++ b/README.md
@@ -236,6 +236,18 @@ Updraft.navigationStackProvider = {
 
 Return screen names ordered root to top. Setting the provider to `null` restores the platform default. Updraft's own screens are always excluded. To send nothing at all, use `UpdraftSettings(sendNavigationStack = false)`.
 
+### Custom screenshot capture
+
+By default the SDK captures the current window when feedback is triggered (`PixelCopy` on Android 7+, `View.draw` on Android 6, the key window on iOS). Replace it when your app renders content the default cannot see, or to redact sensitive areas:
+
+```kotlin
+Updraft.screenshotGrabber = ScreenshotGrabber {
+    myRenderer.captureFrame()?.toPng()   // ByteArray?, or null to open feedback without a screenshot
+}
+```
+
+`capturePng` is a `suspend` function called on the main thread. Exceptions are caught and treated as "no screenshot"; a failing capture never crashes the host app. Set to `null` to restore the default.
+
 ### Logging
 
 `UpdraftSettings(logLevel = LogLevel.Debug)` prints requests and responses to the console. Default is `LogLevel.Error`.
@@ -250,7 +262,7 @@ Version 2.0.0 rebuilds the SDK on Kotlin Multiplatform. `updraft-sdk` stays a dr
 | `Settings.LOG_LEVEL_DEBUG` | `LogLevel.Debug` (also `Error`, `None`) |
 | `Updraft.initialize(this, settings)` + `Updraft.getInstance()?.start()` | `Updraft.start(settings)`, one call, no context argument |
 | `settings.isStoreRelease` | `UpdraftSettings(..., storeRelease = ...)` |
-| `ScreenshotProvider` | not supported yet, screenshots are captured automatically; a custom hook is planned |
+| `ScreenshotProvider` | `Updraft.screenshotGrabber = ScreenshotGrabber { ... }` (since 2.0.1, see Custom screenshot capture) |
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Version 2.0.0 rebuilds the SDK on Kotlin Multiplatform. `updraft-sdk` stays a dr
 
 Use the `sample` project for testing. `./gradlew publishToMavenLocal` installs the current version to Maven Local. Sample keys go into `local.properties` (`updraft.appKey.android`, `updraft.appKey.ios`, `updraft.sdkKey`).
 
+Before every release, run the Android sample on a device (API 26+), tap "Give feedback" or shake, and confirm the feedback sheet opens with a screenshot. The sample renders a hardware bitmap on purpose: it reproduces the screenshot crash that shipped in 1.1.0 and 2.0.0 (#25).
+
 ### Strings (Loco)
 
 UI strings live in `updraft-ui-compose/src/commonMain/composeResources/values*/strings.xml` (en, de) and are shared by both platforms. They are managed on [Loco](https://localise.biz). `./gradlew :updraft-ui-compose:locoFetch` re-fetches them and **overwrites local edits**, so change strings in Loco first, then pull. `locoPush` pushes local strings to Loco and needs a full-access key. Both tasks need `locoApiKey=<key>` in `local.properties`. Plurals live in `plurals.xml`, which Loco does not touch.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "k
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleProcess" }

--- a/sample/androidApp/build.gradle.kts
+++ b/sample/androidApp/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(project(":sample:composeApp"))
     implementation(project(":updraft-sdk"))
     implementation(libs.androidx.activity.compose)
+    implementation("androidx.compose.foundation:foundation:${libs.versions.composeUi.get()}")
 }
 
 val updraftUploadUrl: String = findProperty("updraft_uploadUrl") as? String ?: ""

--- a/sample/androidApp/src/main/kotlin/com/appswithlove/updraftsdk/MainActivity.kt
+++ b/sample/androidApp/src/main/kotlin/com/appswithlove/updraftsdk/MainActivity.kt
@@ -1,8 +1,24 @@
 package com.appswithlove.updraftsdk
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.unit.dp
 
 class MainActivity : ComponentActivity() {
 
@@ -10,7 +26,31 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            SampleApp()
+            Box(modifier = Modifier.fillMaxSize()) {
+                SampleApp()
+                HardwareBitmapImage(modifier = Modifier.align(Alignment.BottomCenter).padding(32.dp))
+            }
         }
     }
+}
+
+/**
+ * Mimics what Coil produces by default on API 26+: a hardware-backed bitmap in the view tree.
+ * Drawing the window into a software Canvas throws
+ * "Software rendering doesn't support hardware bitmaps" as soon as this is on screen.
+ */
+@Composable
+private fun HardwareBitmapImage(modifier: Modifier = Modifier) {
+    val bitmap = remember { createHardwareBitmap() }
+    Image(bitmap = bitmap.asImageBitmap(), contentDescription = "Hardware bitmap", modifier = modifier.size(160.dp))
+}
+
+private fun createHardwareBitmap(): Bitmap {
+    val software = Bitmap.createBitmap(256, 256, Bitmap.Config.ARGB_8888)
+    Canvas(software).apply {
+        drawColor(Color.MAGENTA)
+        drawCircle(128f, 128f, 96f, Paint().apply { color = Color.YELLOW })
+    }
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return software
+    return software.copy(Bitmap.Config.HARDWARE, false).also { software.recycle() }
 }

--- a/updraft-core/build.gradle.kts
+++ b/updraft-core/build.gradle.kts
@@ -48,6 +48,7 @@ kotlin {
             implementation(libs.turbine)
         }
         androidMain.dependencies {
+            implementation(libs.kotlinx.coroutines.android)
             implementation(libs.ktor.client.okhttp)
             implementation(libs.androidx.startup)
             implementation(libs.lifecycle.process)

--- a/updraft-core/gradle.properties
+++ b/updraft-core/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.appswithlove.updraft
 POM_ARTIFACT_ID=updraft-core
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=updraft-core
 POM_DESCRIPTION=Kotlin Multiplatform core logic for connecting with GetUpdraft platform

--- a/updraft-core/src/androidMain/kotlin/com/appswithlove/updraft/platform/Platform.android.kt
+++ b/updraft-core/src/androidMain/kotlin/com/appswithlove/updraft/platform/Platform.android.kt
@@ -9,17 +9,21 @@ import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import android.os.Build
 import android.os.Handler
-import android.os.HandlerThread
+import android.os.Looper
 import android.view.PixelCopy
 import android.view.Window
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
 import androidx.core.net.toUri
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import java.io.ByteArrayOutputStream
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 private class AndroidShakeDetector(private val onShake: () -> Unit) :
     ShakeDetector, SensorEventListener, DefaultLifecycleObserver {
@@ -75,55 +79,55 @@ private class AndroidShakeDetector(private val onShake: () -> Unit) :
 
 actual fun createShakeDetector(onShake: () -> Unit): ShakeDetector = AndroidShakeDetector(onShake)
 
+/**
+ * Reads the composited window content back via [PixelCopy]. Unlike [android.view.View.draw] into a
+ * software canvas, this renders hardware-backed content (Compose GraphicsLayers, hardware bitmaps).
+ * The copy is awaited without blocking the main thread; PNG encoding runs off the main thread.
+ */
 private class AndroidScreenshotGrabber : ScreenshotGrabber {
-    override fun capturePng(): ByteArray? {
+    override suspend fun capturePng(): ByteArray? {
         val activity = CurrentActivityManager.current ?: return null
         val window = activity.window ?: return null
         val view = window.decorView.rootView
         if (view.width == 0 || view.height == 0) return null
         val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-        val captured = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            pixelCopy(window, bitmap)
-        } else {
-            runCatching { view.draw(Canvas(bitmap)) }.isSuccess
-        }
+        val captured = runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                withTimeoutOrNull(PIXEL_COPY_TIMEOUT_MS) { pixelCopy(window, bitmap) } == true
+            } else {
+                view.draw(Canvas(bitmap))
+                true
+            }
+        }.getOrDefault(false)
         if (!captured) {
             bitmap.recycle()
             return null
         }
-        return ByteArrayOutputStream().use { stream ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-            bitmap.recycle()
-            stream.toByteArray()
+        return withContext(Dispatchers.Default) {
+            ByteArrayOutputStream().use { stream ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                bitmap.recycle()
+                stream.toByteArray()
+            }
         }
     }
 
-    /**
-     * Copies the window's rendered content via [PixelCopy], which supports hardware-accelerated
-     * content (Compose GraphicsLayers, hardware bitmaps) that [android.view.View.draw] into a software
-     * canvas cannot render. Runs on the main thread, so the result callback must not be posted to the
-     * main looper while we block on it.
-     */
     @RequiresApi(Build.VERSION_CODES.N)
-    private fun pixelCopy(window: Window, bitmap: Bitmap): Boolean {
-        val thread = HandlerThread("updraft-pixelcopy").apply { start() }
-        return try {
-            val latch = CountDownLatch(1)
-            var success = false
-            PixelCopy.request(window, bitmap, { result ->
-                success = result == PixelCopy.SUCCESS
-                latch.countDown()
-            }, Handler(thread.looper))
-            latch.await(PIXEL_COPY_TIMEOUT_SECONDS, TimeUnit.SECONDS) && success
-        } catch (e: Exception) {
-            false
-        } finally {
-            thread.quitSafely()
+    private suspend fun pixelCopy(window: Window, bitmap: Bitmap): Boolean =
+        suspendCancellableCoroutine { continuation ->
+            val onResult: (Int) -> Unit = { result ->
+                if (continuation.isActive) continuation.resume(result == PixelCopy.SUCCESS)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                val request = PixelCopy.Request.Builder.ofWindow(window).setDestinationBitmap(bitmap).build()
+                PixelCopy.request(request, ContextCompat.getMainExecutor(window.context)) { onResult(it.status) }
+            } else {
+                PixelCopy.request(window, bitmap, onResult, Handler(Looper.getMainLooper()))
+            }
         }
-    }
 
     companion object {
-        private const val PIXEL_COPY_TIMEOUT_SECONDS = 2L
+        private const val PIXEL_COPY_TIMEOUT_MS = 2_000L
     }
 }
 

--- a/updraft-core/src/androidMain/kotlin/com/appswithlove/updraft/platform/Platform.android.kt
+++ b/updraft-core/src/androidMain/kotlin/com/appswithlove/updraft/platform/Platform.android.kt
@@ -7,11 +7,19 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.PixelCopy
+import android.view.Window
+import androidx.annotation.RequiresApi
 import androidx.core.net.toUri
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import java.io.ByteArrayOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 private class AndroidShakeDetector(private val onShake: () -> Unit) :
     ShakeDetector, SensorEventListener, DefaultLifecycleObserver {
@@ -70,14 +78,52 @@ actual fun createShakeDetector(onShake: () -> Unit): ShakeDetector = AndroidShak
 private class AndroidScreenshotGrabber : ScreenshotGrabber {
     override fun capturePng(): ByteArray? {
         val activity = CurrentActivityManager.current ?: return null
-        val view = activity.window.decorView.rootView
+        val window = activity.window ?: return null
+        val view = window.decorView.rootView
         if (view.width == 0 || view.height == 0) return null
         val bitmap = Bitmap.createBitmap(view.width, view.height, Bitmap.Config.ARGB_8888)
-        view.draw(Canvas(bitmap))
-        val stream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
-        bitmap.recycle()
-        return stream.toByteArray()
+        val captured = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            pixelCopy(window, bitmap)
+        } else {
+            runCatching { view.draw(Canvas(bitmap)) }.isSuccess
+        }
+        if (!captured) {
+            bitmap.recycle()
+            return null
+        }
+        return ByteArrayOutputStream().use { stream ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)
+            bitmap.recycle()
+            stream.toByteArray()
+        }
+    }
+
+    /**
+     * Copies the window's rendered content via [PixelCopy], which supports hardware-accelerated
+     * content (Compose GraphicsLayers, hardware bitmaps) that [android.view.View.draw] into a software
+     * canvas cannot render. Runs on the main thread, so the result callback must not be posted to the
+     * main looper while we block on it.
+     */
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun pixelCopy(window: Window, bitmap: Bitmap): Boolean {
+        val thread = HandlerThread("updraft-pixelcopy").apply { start() }
+        return try {
+            val latch = CountDownLatch(1)
+            var success = false
+            PixelCopy.request(window, bitmap, { result ->
+                success = result == PixelCopy.SUCCESS
+                latch.countDown()
+            }, Handler(thread.looper))
+            latch.await(PIXEL_COPY_TIMEOUT_SECONDS, TimeUnit.SECONDS) && success
+        } catch (e: Exception) {
+            false
+        } finally {
+            thread.quitSafely()
+        }
+    }
+
+    companion object {
+        private const val PIXEL_COPY_TIMEOUT_SECONDS = 2L
     }
 }
 

--- a/updraft-core/src/commonMain/kotlin/com/appswithlove/updraft/Updraft.kt
+++ b/updraft-core/src/commonMain/kotlin/com/appswithlove/updraft/Updraft.kt
@@ -6,6 +6,7 @@ import com.appswithlove.updraft.interactor.CheckFeedbackEnabledInteractor
 import com.appswithlove.updraft.interactor.CheckFeedbackResultModel
 import com.appswithlove.updraft.interactor.CheckUpdateInteractor
 import com.appswithlove.updraft.platform.KeyValueStore
+import com.appswithlove.updraft.platform.ScreenshotGrabber
 import com.appswithlove.updraft.platform.ShakeDetector
 import com.appswithlove.updraft.platform.createAppForegroundObserver
 import com.appswithlove.updraft.platform.createKeyValueStore
@@ -14,8 +15,10 @@ import com.appswithlove.updraft.platform.createShakeDetector
 import com.appswithlove.updraft.platform.currentAppInfo
 import com.appswithlove.updraft.platform.currentNavigationStack
 import com.appswithlove.updraft.platform.openUrl
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -117,6 +120,8 @@ object Updraft {
     private var controller: UpdraftController? = null
     private var currentSettings: UpdraftSettings? = null
     private var shakeDetector: ShakeDetector? = null
+    private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+    private var feedbackJob: Job? = null
 
     val settings: UpdraftSettings
         get() = checkNotNull(currentSettings) { "Must call Updraft.start() first" }
@@ -132,6 +137,15 @@ object Updraft {
      * view controller chain on iOS.
      */
     var navigationStackProvider: (() -> List<String>)? = null
+
+    /**
+     * Optional hook to replace the SDK's screenshot capture. Called on the main
+     * thread when feedback is triggered. Return null to open feedback without a
+     * screenshot. When null, the SDK uses the platform default (PixelCopy of the
+     * current window on Android 7+, View.draw on Android 6, the key window on iOS). Exceptions are caught
+     * and treated as "no screenshot".
+     */
+    var screenshotGrabber: ScreenshotGrabber? = null
 
     private fun resolveNavigationStack(): String {
         if (currentSettings?.sendNavigationStack != true) return ""
@@ -160,11 +174,20 @@ object Updraft {
 
     fun checkForUpdate() = requireController().checkForUpdate()
 
+    /**
+     * Captures a screenshot and opens the feedback UI. Returns immediately; the
+     * capture completes asynchronously on the main thread without blocking it.
+     */
     fun showFeedback() {
-        val screenshot = runCatching { createScreenshotGrabber().capturePng() }
-            .onFailure { if (currentSettings?.shouldShowErrors() == true) println("Updraft: screenshot capture failed, opening feedback without one: $it") }
-            .getOrNull()
-        requireController().onFeedbackTriggered(screenshot)
+        val controller = requireController()
+        if (feedbackJob?.isActive == true) return
+        val grabber = screenshotGrabber ?: createScreenshotGrabber()
+        feedbackJob = mainScope.launch {
+            val screenshot = captureScreenshotOrNull(grabber) { message ->
+                if (currentSettings?.shouldShowErrors() == true) println("Updraft: $message")
+            }
+            controller.onFeedbackTriggered(screenshot)
+        }
     }
 
     fun sendFeedback(screenshotPng: ByteArray, type: FeedbackType, description: String, email: String): Flow<Double> =
@@ -189,3 +212,14 @@ object Updraft {
     private fun requireController(): UpdraftController =
         checkNotNull(controller) { "Must call Updraft.start() first" }
 }
+
+/** A failed screenshot must never crash the host app: feedback opens without one instead. */
+internal suspend fun captureScreenshotOrNull(grabber: ScreenshotGrabber, logError: (String) -> Unit): ByteArray? =
+    try {
+        grabber.capturePng()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        logError("screenshot capture failed, opening feedback without one: $e")
+        null
+    }

--- a/updraft-core/src/commonMain/kotlin/com/appswithlove/updraft/Updraft.kt
+++ b/updraft-core/src/commonMain/kotlin/com/appswithlove/updraft/Updraft.kt
@@ -161,7 +161,9 @@ object Updraft {
     fun checkForUpdate() = requireController().checkForUpdate()
 
     fun showFeedback() {
-        val screenshot = createScreenshotGrabber().capturePng()
+        val screenshot = runCatching { createScreenshotGrabber().capturePng() }
+            .onFailure { if (currentSettings?.shouldShowErrors() == true) println("Updraft: screenshot capture failed, opening feedback without one: $it") }
+            .getOrNull()
         requireController().onFeedbackTriggered(screenshot)
     }
 

--- a/updraft-core/src/commonMain/kotlin/com/appswithlove/updraft/platform/Platform.kt
+++ b/updraft-core/src/commonMain/kotlin/com/appswithlove/updraft/platform/Platform.kt
@@ -10,8 +10,13 @@ interface ShakeDetector {
 
 expect fun createShakeDetector(onShake: () -> Unit): ShakeDetector
 
-interface ScreenshotGrabber {
-    fun capturePng(): ByteArray?
+/**
+ * Captures the current screen as PNG when feedback is triggered.
+ * Called on the main thread. Return null when no screenshot is available;
+ * the feedback UI then opens without one. Exceptions are caught by the SDK.
+ */
+fun interface ScreenshotGrabber {
+    suspend fun capturePng(): ByteArray?
 }
 
 expect fun createScreenshotGrabber(): ScreenshotGrabber

--- a/updraft-core/src/commonTest/kotlin/com/appswithlove/updraft/CaptureScreenshotTest.kt
+++ b/updraft-core/src/commonTest/kotlin/com/appswithlove/updraft/CaptureScreenshotTest.kt
@@ -1,0 +1,49 @@
+package com.appswithlove.updraft
+
+import com.appswithlove.updraft.platform.ScreenshotGrabber
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CaptureScreenshotTest {
+
+    @Test
+    fun captureScreenshotOrNull_grabberReturnsBytes_returnsBytes() = runTest {
+        val grabber = ScreenshotGrabber { byteArrayOf(1, 2, 3) }
+        assertContentEquals(byteArrayOf(1, 2, 3), captureScreenshotOrNull(grabber) {})
+    }
+
+    @Test
+    fun captureScreenshotOrNull_grabberThrows_returnsNullAndLogs() = runTest {
+        val logged = mutableListOf<String>()
+        val grabber = ScreenshotGrabber { throw IllegalArgumentException("Software rendering doesn't support hardware bitmaps") }
+
+        assertNull(captureScreenshotOrNull(grabber) { logged += it })
+        assertEquals(1, logged.size)
+        assertTrue(logged.single().contains("hardware bitmaps"))
+    }
+
+    @Test
+    fun captureScreenshotOrNull_grabberThrowsError_returnsNull() = runTest {
+        val grabber = ScreenshotGrabber { throw OutOfMemoryError("bitmap") }
+        assertNull(captureScreenshotOrNull(grabber) {})
+    }
+
+    @Test
+    fun captureScreenshotOrNull_grabberReturnsNull_returnsNullWithoutLog() = runTest {
+        val logged = mutableListOf<String>()
+        assertNull(captureScreenshotOrNull(ScreenshotGrabber { null }) { logged += it })
+        assertTrue(logged.isEmpty())
+    }
+
+    @Test
+    fun captureScreenshotOrNull_cancellation_propagates() = runTest {
+        val grabber = ScreenshotGrabber { throw CancellationException("cancelled") }
+        assertFailsWith<CancellationException> { captureScreenshotOrNull(grabber) {} }
+    }
+}

--- a/updraft-core/src/iosMain/kotlin/com/appswithlove/updraft/platform/Platform.ios.kt
+++ b/updraft-core/src/iosMain/kotlin/com/appswithlove/updraft/platform/Platform.ios.kt
@@ -85,7 +85,7 @@ actual fun createShakeDetector(onShake: () -> Unit): ShakeDetector = IosShakeDet
 
 @OptIn(ExperimentalForeignApi::class)
 private class IosScreenshotGrabber : ScreenshotGrabber {
-    override fun capturePng(): ByteArray? {
+    override suspend fun capturePng(): ByteArray? {
         val window = keyWindow() ?: return null
         val bounds = window.bounds
         val renderer = UIGraphicsImageRenderer(bounds = bounds)

--- a/updraft-sdk/gradle.properties
+++ b/updraft-sdk/gradle.properties
@@ -12,7 +12,7 @@ org.gradle.jvmargs=-Xmx4096m
 
 GROUP=com.appswithlove.updraft
 POM_ARTIFACT_ID=updraft-sdk
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=updraft-sdk
 POM_DESCRIPTION=Updraft SDK for Android: auto-update and user feedback, wired up automatically

--- a/updraft-ui-compose/gradle.properties
+++ b/updraft-ui-compose/gradle.properties
@@ -1,6 +1,6 @@
 GROUP=com.appswithlove.updraft
 POM_ARTIFACT_ID=updraft-ui-compose
-VERSION_NAME=2.0.0
+VERSION_NAME=2.0.1
 
 POM_NAME=updraft-ui-compose
 POM_DESCRIPTION=Compose Multiplatform UI components for the Updraft SDK


### PR DESCRIPTION
Fixes #25

## Problem

Shake-to-feedback crashed the host app on every Jetpack Compose screen and on any View tree containing a hardware bitmap (Coil default on API 26+):

```
java.lang.IllegalArgumentException: Software rendering doesn't support hardware bitmaps
    at android.graphics.BaseCanvas.throwIfHwBitmapInSwMode
    at androidx.compose.ui.platform.AndroidComposeView.dispatchDraw
    at com.appswithlove.updraft.Updraft.showFeedback
    at com.appswithlove.updraft.platform.AndroidShakeDetector.onSensorChanged
```

`AndroidScreenshotGrabber.capturePng()` drew the decor view into a software `Canvas` via `View.draw`, which cannot render hardware-backed content. There was no try/catch, so the exception propagated out of the sensor callback and killed the process. Same defect as the 1.1.0 `DefaultScreenshotProvider` crash; the code moved to KMP in 2.0.0 but was not fixed.

## Fix

**Screenshot capture is now hardware-safe, asynchronous, and replaceable.**

- **`ScreenshotGrabber.capturePng()` is a `suspend fun`** (`fun interface`, commonMain). Called on the main thread, returns `ByteArray?`.
- **Android (`Platform.android.kt`)**: capture via `PixelCopy`, which reads the composited window back from the GPU and therefore renders Compose `GraphicsLayer`s and hardware bitmaps. API 34+ uses `PixelCopy.Request` with the main executor, API 24-33 uses `PixelCopy.request(window, …)` with a main-looper callback. The coroutine awaits the result via `suspendCancellableCoroutine` with a 2 s timeout; nothing blocks the main thread. PNG encoding runs on `Dispatchers.Default`. API 23 keeps `View.draw` as fallback (no hardware bitmaps exist there).
- **`Updraft.showFeedback()`**: launches on a `Dispatchers.Main` scope, ignores overlapping calls while a capture is in flight, and catches any `Throwable` from the grabber (including `OutOfMemoryError`). A failed screenshot logs and opens the feedback UI without one. Screenshot capture can never crash the host app again.
- **New hook `Updraft.screenshotGrabber`**: hosts can supply their own capture (custom renderers, redaction), replacing the 1.x `ScreenshotProvider` that 2.0.0 dropped. Documented in README ("Custom screenshot capture") and the migration table.
- **Sample app**: `MainActivity` renders a `Bitmap.Config.HARDWARE` image so the sample reproduces the crash deterministically without network or Coil.
- **README**: manual release gate added to Local development: run sample on device, trigger feedback, confirm sheet opens with screenshot.
- **Deps**: `kotlinx-coroutines-android` added to `updraft-core` androidMain for `Dispatchers.Main`.

## Verification

Pixel 8 Pro, Android 16, `sample/androidApp`:

| Build | Tap "Give feedback" (same path as shake) |
| --- | --- |
| before fix | `FATAL EXCEPTION: main … Software rendering doesn't support hardware bitmaps`, process dead |
| after fix | feedback sheet opens, screenshot includes the hardware bitmap, 0 crashes |

`:updraft-core:testAndroidHostTest` passes, incl. new `CaptureScreenshotTest` (bytes, null, `Exception`, `OutOfMemoryError`, `CancellationException` paths). iOS simulator targets of `updraft-core` and `updraft-ui-compose` compile.

Not verified: a Swift-side `ScreenshotGrabber` implementation (suspend method surfaces as `capturePng(completionHandler:)` in the ObjC header). Kotlin hosts on iOS are unaffected.

## Release

Ships in 2.0.1 (version bump included in this branch).
